### PR TITLE
Improves the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,8 +3,8 @@ Basic Cucumber Bundle for Sublime Text 2(http://www.sublimetext.com/2)
 
 # Installation
 ## Mac OSX
-    cd /Users/<username>/Library/Application\ Support/Sublime\ Text\ 2/Packages
-    git clone git://github.com/sagework/cucumber-sublime2-bundle.git Cucumber
+    cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages
+    git clone git://github.com/npverni/cucumber-sublime2-bundle.git Cucumber
 ## Linux
     cd ~/.config/sublime-text-2/Packages
     git clone git://github.com/sagework/cucumber-sublime2-bundle.git Cucumber


### PR DESCRIPTION
- the referring repository no longer exists
- on MacOSX you can use the tilde '~' to refer to the current user home directory
