### PR TITLE
Added in the comment character definition

### DIFF
--- a/Cucumber.tmPreferences
+++ b/Cucumber.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Cucumber</string>
+	<key>scope</key>
+	<string>text.gherkin</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string># </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Basic Cucumber Bundle for Sublime Text 2(http://www.sublimetext.com/2)
 
 # Installation
 ## Mac OSX
-    cd /Users/<username>/Library/Application\ Support/Sublime\ Text\ 2/Packages
+    cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages
     git clone git://github.com/npverni/cucumber-sublime2-bundle.git Cucumber
 ## Linux
     cd ~/.config/sublime-text-2/Packages

--- a/README.markdown
+++ b/README.markdown
@@ -4,10 +4,10 @@ Basic Cucumber Bundle for Sublime Text 2(http://www.sublimetext.com/2)
 # Installation
 ## Mac OSX
     cd /Users/<username>/Library/Application\ Support/Sublime\ Text\ 2/Packages
-    git clone git://github.com/sagework/cucumber-sublime2-bundle.git Cucumber
+    git clone git://github.com/npverni/cucumber-sublime2-bundle.git Cucumber
 ## Linux
     cd ~/.config/sublime-text-2/Packages
-    git clone git://github.com/sagework/cucumber-sublime2-bundle.git Cucumber
+    git clone git://github.com/npverni/cucumber-sublime2-bundle.git Cucumber
 ## Windows
     From within Sublime, click "Preferences" from the top menu
     Click "Browse Packages" to open explorer to the packages directory


### PR DESCRIPTION
Add a definition for the comment character so that the toggle_comment
command works in Gherkin files.

E.g. so you can highlight a bunch of text and hit Command-/ (in OSX) to line comment them all at once.
